### PR TITLE
compatible with zig 0.10.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,7 @@ pub fn build(b: *std.build.Builder) void {
     exe.step.dependOn(&cmd.step);
     exe.setTarget(target);
     exe.setBuildMode(mode);
-    exe.addIncludeDir(".");
+    exe.addIncludePath(".");
     exe.addPackage(pkgs.clap);
     exe.install();
 


### PR DESCRIPTION
hi! would you consider bumping zig version to 0.10.0?
this pr updated deps/clap to 0.6.0 and one deprecated api to fix compatiblility issue with zig 0.10.0