### PR TITLE
Fix #5

### DIFF
--- a/src/TtyInterface.zig
+++ b/src/TtyInterface.zig
@@ -52,6 +52,7 @@ pub fn init(
     self.cursor = self.search.len;
 
     try self.updateSearch();
+    try self.draw(true);
 
     return self;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -66,6 +66,11 @@ pub fn main() anyerror!u8 {
     } else {
         if (stdin.isTty()) {
             try choices.readAll();
+        } else if (blk: {
+            const stat = try std.os.fstat(stdin.handle);
+            break :blk std.os.S.ISREG(stat.mode);
+        }) {
+            try choices.readAll();
         }
 
         var tty = try Tty.init(options.tty_filename);


### PR DESCRIPTION
hi! this pr is trying to fix two problems:
1. `ttyInterface.init()` will set its .last_update.num_choices = .choices.numChoices, that prevents TUI be drew at the first time when fzy be run via `fzy -f file`
2. stdin could be a file when user runs fzy using `fzy < file`

(addressing #5)